### PR TITLE
Thoth-14: BPE Considerations

### DIFF
--- a/rust/src/llama2_tokenizer.rs
+++ b/rust/src/llama2_tokenizer.rs
@@ -114,7 +114,7 @@ impl Llama2Tokenizer {
 
         for {
             ...
-        }
+        } 
 
         print("[Thoth => decoder]: Decoding Complete...");
     }

--- a/rust/src/llama2_tokenizer.rs
+++ b/rust/src/llama2_tokenizer.rs
@@ -6,16 +6,16 @@ use indexmap::IndexMap;
 use std::cmp;
 
 pub struct Llama2Tokenizer {
-    vocab: HashMap<usize, (usize, usize)>,
+    vocab: HashMap<usize, char>,
     token_counter: usize,
-    merges: IndexMap<usize, (usize, usize)>
+    // merges: IndexMap<usize, (usize, usize)> PLEASE GET BACK TO THIS
 }
 
 impl Llama2Tokenizer {
     pub fn new() -> Llama2Tokenizer {
         let vocab = HashMap::new();
         let token_counter = 0;
-        let merges = IndexMap::new();
+        // let merges = IndexMap::new(); PLEASE GET BACK TO THIS
         Llama2Tokenizer { vocab, token_counter, merges }
     }
 
@@ -41,31 +41,20 @@ impl Llama2Tokenizer {
         let num_merges: u8 = vocab_size - 256;
 
         for i in 0..num_merges {
-            // Count the frequency of each pair of code points
-            let pair_counts: IndexMap<(usize, usize), usize> = self.count_pair_frequencies(code_points);
+            // Count the frequency of each code point
+            let code_counts: IndexMap<char, usize> = self.count_codepoint_frequencies(code_points);
             
-            // Find the most frequent pair of code points
-            let mut pair: (usize, usize) = (0, 0);
-            let mut freq: &usize = pair_counts.values().next().unwrap();
-            for (key, value) in common_tuples.iter() {
-                if value > freq { 
-                    freq = value;
-                    pair = *key;
-                }
-            }
-
-            if pair == (0, 0) {
-                panic!("[Thoth => train]: For some reason pair unassigned from before.");
-            }
-
-            let most_frequent_pair: (usize, usize) = pair;
-            
-            // Merge the most frequent pair into a new token
+            // Find the most frequent code point
+            let (most_frequent_code_point, _) = code_counts.iter()
+                .max_by_key(|&(_, count)| count)
+                .unwrap();
+        
+            // Merge the most frequent code point into a new token
             let new_token = self.generate_new_token();
             
             // Update the vocabulary and the list of code points
-            self.vocab.insert(new_token, most_frequent_pair);
-            code_points = self.merge_items_replace(code_points, most_frequent_pair, new_token);
+            self.vocab.insert(new_token, most_frequent_code_point);
+            // code_points = self.merge_items_replace(code_points, most_frequent_pair, new_token); // PLEASE COME BACK TO THIS
         }
         
         print("[Thoth => train]: Training complete.")
@@ -77,26 +66,27 @@ impl Llama2Tokenizer {
         }
 
         println!("[Thoth => encoder]: Encoding...");
+
         // Convert the text to a list of Unicode code points
         let mut code_points: Vec<u32> = text.chars().map(|c| c as u32).collect();
 
         // Encode the text using the trained BPE model
         let encoded: Vec<usize> = Vec::new();
 
-        for i in 0..code_points.len() { 
+        while i < code_points.len() { 
             // Start with the longest possible sequence
-            let sequence_length: usize = ;
+            // let sequence_length: usize = ;
             while sequence_length > 0 {
-                let sequence: (, ) = ; 
-                if self.vocab.get(sequence) { 
-                    encoded.push(self.vocab.get(sequence));
-                    i += sequence_length;
-                    break
-                } else {
-                    encoded.push(code_points[i]);
-                    i += 1;
-                }
-                sequence_length -= 1; 
+                // let sequence: (, ) = ; 
+                // if self.vocab.get(sequence) { 
+                //     encoded.push(self.vocab.get(sequence));
+                //     i += sequence_length;
+                //     break
+                // } else {
+                //     encoded.push(code_points[i]);
+                //     i += 1;
+                // }
+                // sequence_length -= 1; 
             }
         }
 
@@ -112,9 +102,9 @@ impl Llama2Tokenizer {
 
         let decoded: Vec<usize> = Vec::new();
 
-        for {
-            ...
-        } 
+        // for {
+        //     ...
+        // } 
 
         print("[Thoth => decoder]: Decoding Complete...");
     }
@@ -123,30 +113,30 @@ impl Llama2Tokenizer {
     /////////////////// HELPER FUNCTIONS ///////////////////
     ////////////////////////////////////////////////////////
 
-    fn count_pair_frequencies(code_points: Vec<u32>) -> HashMap<(usize, usize), usize> {
-        let mut pair_counts = HashMap::new();
-        for window in code_points.windows(2) {
-            if let [a, b] = window {
-                *pair_counts.entry((*a, *b)).or_insert(0) += 1;
+    fn count_codepoint_frequencies(code_points: Vec<u32>) -> HashMap<char, usize> {
+        let mut counts = HashMap::new();
+        for &codepoint in &code_points {
+            if let Some(char) = std::char::from_u32(codepoint) {
+                *counts.entry(char).or_insert(0) += 1;
             }
         }
-        pair_counts
+        counts
     }
 
-    fn merge_items_replace(items: Vec<usize>, pair: (usize, usize), new_item: usize) -> Vec<usize> {
-        let mut merged_items = Vec::new();
-        let mut i = 0;
-        while i < items.len() {
-            if i + 1 < items.len() && (items[i], items[i + 1]) == pair {
-                merged_items.push(new_item);
-                i += 2;
-            } else {
-                merged_items.push(items[i]);
-                i += 1;
-            }
-        }
-        merged_items
-    }
+    // fn merge_items_replace(items: Vec<usize>, pair: (usize, usize), new_item: usize) -> Vec<usize> {
+    //     let mut merged_items = Vec::new();
+    //     let mut i = 0;
+    //     while i < items.len() {
+    //         if i + 1 < items.len() && (items[i], items[i + 1]) == pair {
+    //             merged_items.push(new_item);
+    //             i += 2;
+    //         } else {
+    //             merged_items.push(items[i]);
+    //             i += 1;
+    //         }
+    //     }
+    //     merged_items
+    // }
     
     fn generate_new_token(&mut self) -> usize {
         let new_token = self.token_counter;


### PR DESCRIPTION
### Background: 
- It seems that a codepoint can be perfectly mapped to a single u32 in rust, unlike how UTF-8 does it. 
- So here we may not have mappings of tuples of integers for a codepoint
- This means we don't necessarily merge tuples anymore and potentially we could be extending our vocabulary to be too large (we don't perform merges to reduce our vocabulary to begin with)
- So I might need to consider merging the char -> codepoint translations themselves, similar to the basicTokenizer BPE system
- Will need to explore UTF-8 vs Rust codepoints for more clarity and to be able to continue with implementation

### Changes: 
- Commented out affected functionality
- Changed existing functionality that is affected given that each character maps to a singular codepoint

### Tests:
- TBD